### PR TITLE
Fix chart builder soql

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@
 coverage/
 .vscode
 _site/
+tests/

--- a/__tests__/unit/chartBuilder.test.js
+++ b/__tests__/unit/chartBuilder.test.js
@@ -97,6 +97,16 @@ describe('test property', () => {
     // Validate parameters of mocked Apex call
     expect(element.soql).toEqual(`'${element.recordId}'`);
   });
+
+  test('detailsLabels error', () => {
+    const element = createElement('c-chartBuilder', { is: ChartBuilder });
+    document.body.appendChild(element);
+    element.recordId;
+    element.soql = ':recordId';
+
+    // Validate parameters of mocked Apex call
+    expect(element.soql).toEqual(`'${ChartBuilder.FAKE_ID}'`);
+  });
 });
 
 const flushPromises = () => {

--- a/__tests__/unit/chartBuilder.test.js
+++ b/__tests__/unit/chartBuilder.test.js
@@ -51,7 +51,7 @@ describe('call server and get chart data when', () => {
   });
 
   test('error occurs in the server side', () => {
-    getChartData.mockResolvedValue(APEX_ERROR);
+    getChartData.mockRejectedValue(APEX_ERROR);
     const element = createElement('c-chartBuilder', { is: ChartBuilder });
     document.body.appendChild(element);
 

--- a/force-app/main/default/classes/SOQLDataProvider.cls
+++ b/force-app/main/default/classes/SOQLDataProvider.cls
@@ -9,6 +9,7 @@ public inherited sharing virtual class SOQLDataProvider extends ChartDataProvide
   private static final String SOQL_LIMIT_STATEMENT = 'LIMIT';
   private static final String LABEL_ALIAS = 'label';
   private static final String VALUE_ALIAS = 'value';
+  private static final String UNDEFINED_RECORDID = '\'xxxxxxxxxxxxxxx\'';
 
   public static final String QUERY_NULL_EXCEPTION = 'Query is null';
   public static final String QUERY_WITHOUT_LABEL_EXCEPTION = 'Query must contains "label" alias';
@@ -64,9 +65,14 @@ public inherited sharing virtual class SOQLDataProvider extends ChartDataProvide
     }
 
     final List<ChartDataProvider.ChartData> chartDatas = new List<ChartDataProvider.ChartData>();
-    for (
-      AggregateResult aResult : Database.query(String.escapeSingleQuotes(query))
-    ) {
+    System.debug(this.query);
+    // When building the chart in the app builder and using :recordId in the query
+    // The context is not set and :recordId is undefined
+    // In this case we can't get not data but it is still possible to build the chart in the App Builder
+    if (this.query.contains(UNDEFINED_RECORDID)) {
+      return chartDatas;
+    }
+    for (AggregateResult aResult : Database.query(this.query)) {
       ChartDataProvider.ChartData aChartData = new ChartDataProvider.ChartData();
       aChartData.label = (String) aResult.get(LABEL_ALIAS);
       aChartData.detail = new List<Object>{ aResult.get(VALUE_ALIAS) };

--- a/force-app/main/default/classes/SOQLDataProvider.cls
+++ b/force-app/main/default/classes/SOQLDataProvider.cls
@@ -9,7 +9,7 @@ public inherited sharing virtual class SOQLDataProvider extends ChartDataProvide
   private static final String SOQL_LIMIT_STATEMENT = 'LIMIT';
   private static final String LABEL_ALIAS = 'label';
   private static final String VALUE_ALIAS = 'value';
-  private static final String UNDEFINED_RECORDID = '\'xxxxxxxxxxxxxxx\'';
+  public static final String UNDEFINED_RECORDID = '\'xxxxxxxxxxxxxxx\'';
 
   public static final String QUERY_NULL_EXCEPTION = 'Query is null';
   public static final String QUERY_WITHOUT_LABEL_EXCEPTION = 'Query must contains "label" alias';

--- a/force-app/main/default/classes/SOQLDataProvider.cls
+++ b/force-app/main/default/classes/SOQLDataProvider.cls
@@ -65,7 +65,6 @@ public inherited sharing virtual class SOQLDataProvider extends ChartDataProvide
     }
 
     final List<ChartDataProvider.ChartData> chartDatas = new List<ChartDataProvider.ChartData>();
-    System.debug(this.query);
     // When building the chart in the app builder and using :recordId in the query
     // The context is not set and :recordId is undefined
     // In this case we can't get not data but it is still possible to build the chart in the App Builder

--- a/force-app/main/default/classes/SOQLDataProviderTest.cls
+++ b/force-app/main/default/classes/SOQLDataProviderTest.cls
@@ -117,6 +117,20 @@ private class SOQLDataProviderTest {
   }
 
   @isTest
+  static void testAppBuilderContext() {
+    Test.startTest();
+    final SOQLDataProvider aSOQLDataProvider = new SOQLDataProvider();
+    aSOQLDataProvider.init(
+      'SELECT StageName label, SUM(Amount) value FROM Opportunity WHERE IsClosed = false AND AccountId = ' +
+      SOQLDataProvider.UNDEFINED_RECORDID +
+      ' WITH SECURITY_ENFORCED GROUP BY StageName LIMIT 10'
+    );
+    final List<ChartDataProvider.ChartData> chartDatas = aSOQLDataProvider.getData();
+    Test.stopTest();
+    System.assertEquals(0, chartDatas.size(), 'chartDatas must be empty');
+  }
+
+  @isTest
   static void testGetData() {
     insert new Opportunity(
       CloseDate = date.today().addMonths(2),

--- a/force-app/main/default/lwc/chart/chart.js
+++ b/force-app/main/default/lwc/chart/chart.js
@@ -34,6 +34,7 @@ export default class Chart extends LightningElement {
     return this._canvasOnchange;
   }
   set canvasOnchange(v) {
+    this.getCanvas().removeEventListener('mouseover', this._canvasOnchange);
     this._canvasOnchange = v;
     this.getCanvas().addEventListener('change', this._canvasOnchange);
   }
@@ -43,6 +44,10 @@ export default class Chart extends LightningElement {
     return this._canvasOnclick;
   }
   set canvasOnclick(v) {
+    this.getCanvas().removeEventListener(
+      'mouseover',
+      this._canvas_canvasOnclickOnmouseover
+    );
     this._canvasOnclick = v;
     this.getCanvas().addEventListener('click', this._canvasOnclick);
   }
@@ -52,6 +57,7 @@ export default class Chart extends LightningElement {
     return this._canvasOnmouseover;
   }
   set canvasOnmouseover(v) {
+    this.getCanvas().removeEventListener('mouseover', this._canvasOnmouseover);
     this._canvasOnmouseover = v;
     this.getCanvas().addEventListener('mouseover', this._canvasOnmouseover);
   }
@@ -61,6 +67,7 @@ export default class Chart extends LightningElement {
     return this._canvasOnmouseout;
   }
   set canvasOnmouseout(v) {
+    this.getCanvas().removeEventListener('mouseover', this._canvasOnmouseout);
     this._canvasOnmouseout = v;
     this.getCanvas().addEventListener('mouseout', this._canvasOnmouseout);
   }

--- a/force-app/main/default/lwc/chartBuilder/chartBuilder.js
+++ b/force-app/main/default/lwc/chartBuilder/chartBuilder.js
@@ -50,6 +50,10 @@ export default class ChartBuilder extends LightningElement {
     }
   }
 
+  // This is where the data are build and given to the chart.
+  // It is set either directly via the app builder
+  // or by the soql setter which call the imperative apex method
+  // or by the handler setter which call the imperative apex method
   _details = [];
   @api
   get details() {
@@ -69,6 +73,7 @@ export default class ChartBuilder extends LightningElement {
       this.error = false;
     } catch (error) {
       this.errorCallback(error);
+      this._details = null;
       data = null;
     }
     return data;
@@ -86,7 +91,14 @@ export default class ChartBuilder extends LightningElement {
   set soql(v) {
     this._soql = v;
     if (this._soql) {
-      this._soql = this._soql.replace(/:recordId/g, `'${this.recordId}'`);
+      this._soql = this._soql.replace(
+        /:recordId/g,
+        `'${
+          this.recordId
+            ? this.recordId.replace("'", "\\'")
+            : ChartBuilder.FAKE_ID
+        }'`
+      );
       this._getChartDataHandler(
         ChartBuilder.SOQL_DATA_PROVIDER_APEX_TYPE,
         this._soql
@@ -130,7 +142,7 @@ export default class ChartBuilder extends LightningElement {
         this.details = result;
       })
       .catch(error => {
-        this.errorCallback(error);
+        this.errorCallback(error.body.message);
       });
   }
 
@@ -204,6 +216,7 @@ export default class ChartBuilder extends LightningElement {
     ]
   };
 
+  static FAKE_ID = 'xxxxxxxxxxxxxxx';
   static SOQL_DATA_PROVIDER_APEX_TYPE = 'SOQLDataProvider';
   static DEFAULT_CSS_CLASS = 'slds-card slds-p-around_small';
 }

--- a/force-app/main/default/lwc/chartBuilder/chartBuilder.js-meta.xml
+++ b/force-app/main/default/lwc/chartBuilder/chartBuilder.js-meta.xml
@@ -12,6 +12,7 @@
     <target>lightning__AppPage</target>
     <target>lightning__HomePage</target>
     <target>lightning__RecordPage</target>
+    <target>lightningCommunity__Page</target>
     <target>lightningCommunity__Default</target>
   </targets>
   <targetConfigs>

--- a/force-app/sample/default/lwc/sampleApp/sampleApp.js-meta.xml
+++ b/force-app/sample/default/lwc/sampleApp/sampleApp.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>48.0</apiVersion>
     <isExposed>true</isExposed>
-    <masterLabel>LWCCSamples</masterLabel>
+    <masterLabel>LWCC Chart Samples</masterLabel>
   <description>See different examples of charts using LWCC</description>
     <targets>
         <target>lightning__AppPage</target>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint:lwc": "eslint force-app/main/default/lwc && eslint force-app/sample/default/lwc",
     "lint:apex": "pmd pmd -minimumpriority 2 -d force-app -R apex-ruleset.xml -f text -l apex",
     "test": "npm run test:unit && npm run test:apex",
+    "test:clear:cache": "sfdx-lwc-jest -- --clearCache",
     "test:coverage": "npm run test:unit:coverage && npm run test:apex:coverage",
     "test:apex": "sfdx force:apex:test:run -r tap -d ./tests/apex -s lwcc -w 20",
     "test:apex:coverage": "sfdx force:apex:test:run -r tap -d ./tests/apex -s lwcc -w 20 -c",


### PR DESCRIPTION
SOQL issue in the App builder with recordId

## Description

recordId is null in the app builder and so it breaks the record fetching when set in the SOQL query
plus the escaping of the recordId broke the soql itself
plus the recordId itself was not escaped and the code was exposed to SOQL injection

## Motivation and Context

This change improve :
- quality of the code
- user experience in the app build
- security of the chartBuilder component

## How Has This Been Tested?

Unit UI test (soql, data, customDataProvider in App page, Record Page, Home Page and Community Page)
Apex test
Jest test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
